### PR TITLE
Add arm64 Docker image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,6 +173,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Docker meta
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: |
+            ghcr.io/intro-skipper/jellyfin-se
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
       - name: Login Registry
         uses: docker/login-action@v1
         with:
@@ -187,5 +198,5 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/intro-skipper/jellyfin-se:latest
+          tags: ${{ steps.meta.outputs.tags }}
           push: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,7 +180,12 @@ jobs:
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Build Image
-        run: |
-          docker build . --tag ghcr.io/intro-skipper/jellyfin-se:latest
-          docker push ghcr.io/intro-skipper/jellyfin-se:latest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/intro-skipper/jellyfin-se:latest
+          push: true


### PR DESCRIPTION
Wanted to deploy this app on a Raspberry Pi, next to my Jellyfin instance but out of the box it is only shipped as a Docker image for `amd64`. Found out it builds and runs just fine for `arm64` too.

This PR changes the release workflow to build for both x64 and arm64 architectures.
Additionally, it adds proper version tags to the docker images as previously only the `latest` tag was provided. (Now still is, just in addition to versioned tags)