### PR TITLE
Fix Docker Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build
-FROM node:20.9-alpine AS build-step
+FROM node:lts-alpine AS build-step
 
 LABEL org.opencontainers.image.description="https://github.com/intro-skipper/segment-editor"
 


### PR DESCRIPTION
Docker builds have been broken for a while, caused by upstream packages no longer supporting older Node versions. Throwing the following error: 
```
import { styleText } from "node:util";
         ^^^^^^^^^
SyntaxError: The requested module 'node:util' does not provide an export named 'styleText'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:131:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:213:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:316:24)
    at async #build (file:///app/node_modules/@quasar/app-vite/lib/quasar-config-file.js:333:24)
    at async file:///app/node_modules/@quasar/app-vite/lib/cmd/build.js:138:20
```

In non-docker release builds no Node version is specified, other than `lts`. This PR changes the docker builds to also use `lts` as the base image for the build process.